### PR TITLE
Fix test failure when uint is properly unsigned

### DIFF
--- a/t/tt_sfnt.t
+++ b/t/tt_sfnt.t
@@ -41,7 +41,7 @@ my TT_OS2 $os2 .= load: :$face;
 is $os2.version, 1;
 is $os2.usWeightClass, 400;
 is $os2.usWinDescent, 483;
-is $os2.usUpperPointSize, -1|255;
+is $os2.usUpperPointSize, -1|65535;
 is $os2.panose.bSerifStyle, 11;
 is $os2.panose.bXHeight, 4;
 is $os2.achVendID, 'PfEd';


### PR DESCRIPTION
usUpperPointSize returns a uint16. Previously Rakudo turned the return value of 0xFFFF
into -1. The test was anticipating a fix, but incorrectly expected 0xFF. Fix the test to
support both the old behavior of getting -1 and the correct one of getting 0xFFFF.